### PR TITLE
feat: added vcd_parser and result.json files as example

### DIFF
--- a/source/result.json
+++ b/source/result.json
@@ -1,0 +1,2398 @@
+{
+    "TOP.ariane_testharness": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/ariane_testharness.sv",
+        "initialization_path": null
+    },
+    "TOP.ariane_testharness.i_ariane": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/src/ariane.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.gen_example_coprocessor.i_cvxif_coprocessor": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_example/cvxif_example_coprocessor.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/src/ariane.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.gen_example_coprocessor.i_cvxif_coprocessor.compressed_instr_decoder_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_example/compressed_instr_decoder.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_example/cvxif_example_coprocessor.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.gen_example_coprocessor.i_cvxif_coprocessor.i_copro_alu": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_example/copro_alu.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_example/cvxif_example_coprocessor.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.gen_example_coprocessor.i_cvxif_coprocessor.instr_decoder_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_example/instr_decoder.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_example/cvxif_example_coprocessor.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/src/ariane.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.commit_stage_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/commit_stage.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.controller_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/controller.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.csr_regfile_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/csr_regfile.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ex_stage.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.alu2_gen.alu2_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/alu.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ex_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.alu2_gen.alu2_i.gen_bitmanip.i_clz_64b": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/alu.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.alu2_gen.alu2_i.gen_bitmanip.i_cpop_count": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/popcount.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/alu.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.alu_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/alu.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ex_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.alu_i.gen_bitmanip.i_clz_64b": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/alu.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.alu_i.gen_bitmanip.i_cpop_count": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/popcount.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/alu.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.branch_unit_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/branch_unit.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ex_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.csr_buffer_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/csr_buffer.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ex_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.gen_cvxif.cvxif_fu_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_fu.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ex_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.i_mult": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/mult.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ex_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.i_mult.i_div": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/serdiv.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/mult.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.i_mult.i_div.i_lzc_a": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/serdiv.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.i_mult.i_div.i_lzc_b": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/serdiv.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.i_mult.i_multiplier": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/multiplier.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/mult.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_store_unit.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ex_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_load_unit": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_unit.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_store_unit.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_load_unit.ldbuf_free_index_multi_gen.lzc_windex_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_unit.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pipe_reg_load": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/shift_reg.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_store_unit.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pipe_reg_store": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/shift_reg.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_store_unit.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp_data_if.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_store_unit.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp_data_if.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[0].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[0].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[1].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[1].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[2].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[2].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[3].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[3].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[4].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[4].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[5].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[5].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[6].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[6].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[7].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_data.gen_pmp.genblk1[7].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp_data_if.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[0].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[0].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[1].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[1].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[2].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[2].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[3].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[3].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[4].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[4].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[5].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[5].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[6].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[6].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[7].i_pmp_entry": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/pmp/src/pmp.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_pmp_data_if.i_pmp_if.gen_pmp.genblk1[7].i_pmp_entry.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_store_unit": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/store_unit.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_store_unit.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.i_store_unit.store_buffer_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/store_buffer.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/store_unit.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.ex_stage_i.lsu_i.lsu_bypass_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/lsu_bypass.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/load_store_unit.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_axi_arbiter": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_axi_arbiter.genblk1.i_icache_hpdcache_data_upsize": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_axi_arbiter.genblk1.i_icache_refill_meta_fifo": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_axi_arbiter.i_hpdcache_mem_to_axi_read": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_axi_arbiter.i_hpdcache_mem_to_axi_write": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_axi_arbiter.i_icache_miss_req_fifo": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_axi_arbiter.i_mem_req_read_arbiter": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_axi_arbiter.i_mem_resp_read_demux": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[0].data_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram_cache.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[0].data_sram.gen_techno_cut.genblk1.i_tc_sram_wrapper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[0].data_sram.gen_techno_cut.genblk1.i_tc_sram_wrapper.i_tc_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[0].tag_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_mmu/cva6_shared_tlb.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[0].tag_sram.gen_techno_cut.genblk1.i_tc_sram_wrapper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[0].tag_sram.gen_techno_cut.genblk1.i_tc_sram_wrapper.i_tc_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[1].data_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram_cache.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[1].data_sram.gen_techno_cut.genblk1.i_tc_sram_wrapper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[1].data_sram.gen_techno_cut.genblk1.i_tc_sram_wrapper.i_tc_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[1].tag_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_mmu/cva6_shared_tlb.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[1].tag_sram.gen_techno_cut.genblk1.i_tc_sram_wrapper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.gen_sram[1].tag_sram.gen_techno_cut.genblk1.i_tc_sram_wrapper.i_tc_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.i_lfsr": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lfsr.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_mmu/cva6_shared_tlb.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.i_lzc": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_burst_splitter.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_cva6_icache.i_lzc_hit": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_icache.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_subsystem.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.gen_cva6_hpdcache_load_if_adapter[0].i_cva6_hpdcache_load_if_adapter": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.gen_cva6_hpdcache_load_if_adapter[1].i_cva6_hpdcache_load_if_adapter": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.gen_cva6_hpdcache_load_if_adapter[2].i_cva6_hpdcache_load_if_adapter": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_cva6_hpdcache_store_if_adapter": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hpdcache": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hpdcache.hpdcache_ctrl_i.hpdcache_memctrl_i.gen_data_sram_row[0].gen_data_sram_col[0].gen_data_sram_wbyteenable.data_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram_cache.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hpdcache.hpdcache_ctrl_i.hpdcache_memctrl_i.gen_data_sram_row[0].gen_data_sram_col[0].gen_data_sram_wbyteenable.data_sram.ram_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/common/core_mem.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/common/core_mem.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hpdcache.hpdcache_ctrl_i.hpdcache_memctrl_i.gen_data_sram_row[0].gen_data_sram_col[1].gen_data_sram_wbyteenable.data_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram_cache.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hpdcache.hpdcache_ctrl_i.hpdcache_memctrl_i.gen_data_sram_row[0].gen_data_sram_col[1].gen_data_sram_wbyteenable.data_sram.ram_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/common/core_mem.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/common/core_mem.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hpdcache.hpdcache_ctrl_i.hpdcache_memctrl_i.gen_dir_sram[0].dir_sram.ram_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/common/core_mem.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/common/core_mem.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hpdcache.hpdcache_ctrl_i.hpdcache_memctrl_i.gen_dir_sram[1].dir_sram.ram_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/common/core_mem.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/common/core_mem.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hpdcache.hpdcache_miss_handler_i.i_data_resize.gen_noresize.fifo_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_fifo.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_fifo.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.gen_cache_hpd.i_cache_subsystem.i_dcache.i_hwpf_stride_wrapper": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/cva6_hpdcache_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_cva6_rvfi_probes": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_rvfi_probes.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.bht_gen.i_bht": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/bht.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.gen_instr_scan[0].i_instr_scan": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_scan.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.gen_instr_scan[1].i_instr_scan": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_scan.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.gen_instr_scan[2].i_instr_scan": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_scan.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.gen_instr_scan[3].i_instr_scan": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_scan.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_queue": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_queue.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_queue.gen_instr_fifo[0].i_fifo_instr_data": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_queue.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_queue.gen_instr_fifo[1].i_fifo_instr_data": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_queue.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_queue.gen_instr_fifo[2].i_fifo_instr_data": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_queue.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_queue.gen_instr_fifo[3].i_fifo_instr_data": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_queue.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_queue.gen_multiple_instr_per_fetch_with_C.i_lzc_branch_index": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_queue.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_queue.gen_multiple_instr_per_fetch_with_C.i_popcount": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/popcount.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_queue.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_queue.i_fifo_address": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/instr_queue.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.i_instr_realign": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/instr_realign.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.i_frontend.ras_gen.i_ras": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/ras.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/frontend/frontend.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.id_stage_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/id_stage.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.id_stage_i.genblk1.genblk1[0].compressed_decoder_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/id_stage.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/id_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.id_stage_i.genblk1.genblk1[1].compressed_decoder_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/id_stage.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/id_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.id_stage_i.genblk1.genblk2.i_cvxif_compressed_if_driver_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_compressed_if_driver.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/id_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.id_stage_i.genblk2[0].decoder_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/decoder.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/id_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.id_stage_i.genblk2[1].decoder_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/decoder.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/id_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_stage.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_asic_regfile.i_ariane_regfile": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/ariane_regfile_ff.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[0].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[10].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[11].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[12].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[13].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[14].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[15].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[16].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[17].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[18].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[19].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[1].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[20].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[21].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[22].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[23].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[24].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[25].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[26].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[27].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[28].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[29].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[2].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[30].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[31].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[3].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[4].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[5].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[6].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[7].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[8].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.gen_sel_clobbers[9].i_sel_gpr_clobbers": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.genblk5[0].i_sel_rs1": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.genblk5[0].i_sel_rs2": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.genblk5[0].i_sel_rs3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.genblk5[1].i_sel_rs1": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.genblk5[1].i_sel_rs2": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.genblk5[1].i_sel_rs3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_issue_read_operands.i_cvxif_issue_register_commit_if_driver": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cvxif_issue_register_commit_if_driver.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_read_operands.sv"
+    },
+    "TOP.ariane_testharness.i_ariane.i_cva6.issue_stage_i.i_scoreboard": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/scoreboard.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/issue_stage.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_peripherals_xilinx.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_peripherals_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_ar_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_ar_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_ar_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_aw_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_aw_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_aw_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_b_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_b_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_b_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_r_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_r_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_r_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_w_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_w_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_axi2apb_64_32_timer.slave_w_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.gen_timer.i_timer": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_peripherals_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_peripherals_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_ar_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_ar_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_ar_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_aw_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_aw_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_aw_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_b_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_b_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_b_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_r_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_r_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_r_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_w_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_w_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_plic.slave_w_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_peripherals_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_ar_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_ar_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_ar_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_aw_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_aw_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_aw_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_b_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_b_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_b_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_r_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_r_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_r_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_w_buffer_i.i_axi_single_slice.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_w_buffer_i.i_axi_single_slice.i_fifo.impl": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_axi2apb_64_32_uart.slave_w_buffer_i.i_axi_single_slice.i_fifo.impl.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_ariane_peripherals.i_plic": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_peripherals_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_axi2mem": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/ariane_testharness.sv"
+    },
+    "TOP.ariane_testharness.i_axi2rom": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_axi_delayer": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_delayer.i_axi_delayer": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_delayer.i_axi_delayer.i_stream_delay_ar": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_delay.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_delayer.i_axi_delayer.i_stream_delay_aw": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_delayer.i_axi_delayer.i_stream_delay_b": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_delay.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_delayer.i_axi_delayer.i_stream_delay_r": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_delay.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_delayer.i_axi_delayer.i_stream_delay_w": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_delay.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_delayer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_riscv_atomics": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_axi_riscv_atomics.i_atomics.i_lrsc.i_non_excl_acc_arb.i_arb": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_arbiter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_arbiter.sv"
+    },
+    "TOP.ariane_testharness.i_axi_riscv_atomics.i_atomics.i_lrsc.i_non_excl_acc_arb.i_arb.gen_rr_arb.i_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_arbiter_flushable.sv"
+    },
+    "TOP.ariane_testharness.i_axi_riscv_atomics.i_atomics.i_lrsc.i_non_excl_acc_arb.i_arb.gen_rr_arb.i_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_riscv_atomics.i_atomics.i_lrsc.i_non_excl_acc_arb.i_arb.gen_rr_arb.i_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_lite_xbar.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_lite_xbar.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[0].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[1].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[2].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[3].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[4].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[5].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[6].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[7].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[8].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.gen_id_prepend[0].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.gen_id_prepend[1].i_id_prepend": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_ar_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_ar_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_aw_arbiter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_aw_arbiter.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_mst_port_mux[9].i_axi_mux.gen_mux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_ar_decode": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/addr_decode.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_lite_xbar.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_aw_decode": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_lite_xbar.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_lite_xbar.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_id_serialize.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_id_serialize.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[0].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[10].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[11].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[12].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[13].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[14].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[15].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[1].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[2].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[3].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[4].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[5].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[6].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[7].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[8].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[9].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[0].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[10].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[11].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[12].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[13].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[14].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[15].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[1].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[2].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[3].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[4].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[5].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[6].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[7].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[8].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[9].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_b_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_b_mux.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_b_mux.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_r_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_r_mux.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_r_mux.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_demux.gen_demux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_dw_upsizer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.genblk1.i_atop_filter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.genblk1.i_atop_filter.r_resp_cmd": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_atop_filter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_atop_filter.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.genblk1.i_atop_filter.r_resp_cmd.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.genblk1.i_atop_filter.r_resp_cmd.i_fifo.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.i_b_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.i_r_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.i_r_counter.i_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.i_r_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[0].i_axi_err_slv.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_ar_decode": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/addr_decode.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_lite_xbar.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_aw_decode": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_lite_xbar.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_lite_xbar.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_id_serialize.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_id_serialize.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[0].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[10].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[11].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[12].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[13].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[14].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[15].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[1].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[2].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[3].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[4].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[5].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[6].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[7].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[8].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_ar_id_counter.i_ar_id_counter.gen_counters[9].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[0].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[10].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[11].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[12].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[13].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[14].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[15].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[1].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[2].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[3].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[4].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[5].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[6].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[7].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[8].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.gen_aw_id_counter.i_aw_id_counter.gen_counters[9].i_in_flight_cnt": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_ar_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_ar_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_aw_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_aw_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_b_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_b_mux.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_b_mux.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_b_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_b_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_r_mux": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_demux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_r_mux.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_lower": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/lzc.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_r_mux.gen_arbiter.gen_int_rr.gen_fair_arb.i_lzc_upper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_r_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_r_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_w_spill_reg": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_demux.gen_demux.i_w_spill_reg.spill_register_flushable_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/spill_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_dw_upsizer.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.genblk1.i_atop_filter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.genblk1.i_atop_filter.r_resp_cmd": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_atop_filter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_atop_filter.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.genblk1.i_atop_filter.r_resp_cmd.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.genblk1.i_atop_filter.r_resp_cmd.i_fifo.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.i_b_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.i_r_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.i_r_counter.i_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.i_r_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_axi_xbar.i_xbar.gen_slv_port_demux[1].i_axi_err_slv.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_clint": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/clint/clint.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_clint.axi_lite_interface_i": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/clint/clint.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/clint/clint.sv"
+    },
+    "TOP.ariane_testharness.i_clint.i_sync_edge.i_sync": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/sync_wedge.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/sync_wedge.sv"
+    },
+    "TOP.ariane_testharness.i_cva6_rvfi": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cva6_rvfi.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/ariane_testharness.sv"
+    },
+    "TOP.ariane_testharness.i_dm_axi2mem": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_dm_axi_master": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/core/cache_subsystem/axi_adapter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_dm_top": {
+        "declaration_path": null,
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    },
+    "TOP.ariane_testharness.i_dm_top.i_dm_csrs.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_dm_top.i_dm_csrs.i_fifo.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_dmi_jtag": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/altera/src/dmi_vjtag.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/altera/src/cva6_altera.sv"
+    },
+    "TOP.ariane_testharness.i_dmi_jtag.i_dmi_cdc.i_cdc_req.i_dst": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/cdc_2phase.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/cdc_2phase.sv"
+    },
+    "TOP.ariane_testharness.i_dmi_jtag.i_dmi_cdc.i_cdc_req.i_src": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/cdc_2phase.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/cdc_2phase.sv"
+    },
+    "TOP.ariane_testharness.i_dmi_jtag.i_dmi_cdc.i_cdc_resp.i_dst": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/cdc_2phase.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/cdc_2phase.sv"
+    },
+    "TOP.ariane_testharness.i_dmi_jtag.i_dmi_cdc.i_cdc_resp.i_src": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/cdc_2phase.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/cdc_2phase.sv"
+    },
+    "TOP.ariane_testharness.i_dmi_jtag.i_dmi_jtag_tap": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/altera/src/dmi_vjtag.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/altera/src/dmi_vjtag.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/ariane_testharness.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.genblk1.i_atop_filter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.genblk1.i_atop_filter.r_resp_cmd": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_atop_filter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_atop_filter.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.genblk1.i_atop_filter.r_resp_cmd.i_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/stream_register.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.genblk1.i_atop_filter.r_resp_cmd.i_fifo.i_fifo_v3": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.i_b_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.i_r_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.i_r_counter.i_counter": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/counter.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.i_r_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_err_slv.sv"
+    },
+    "TOP.ariane_testharness.i_gpio_err_slv.i_w_fifo": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/fifo_v3.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/axi/src/axi_mux.sv"
+    },
+    "TOP.ariane_testharness.i_rvfi_tracer": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/rvfi_tracer.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/ariane_testharness.sv"
+    },
+    "TOP.ariane_testharness.i_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/ariane_testharness.sv"
+    },
+    "TOP.ariane_testharness.i_sram.gen_cut[0].gen_mem_user.i_tc_sram_wrapper_user": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram.sv"
+    },
+    "TOP.ariane_testharness.i_sram.gen_cut[0].gen_mem_user.i_tc_sram_wrapper_user.i_tc_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv"
+    },
+    "TOP.ariane_testharness.i_sram.gen_cut[0].i_tc_sram_wrapper": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/vendor/pulp-platform/common_cells/src/deprecated/sram.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/sram.sv"
+    },
+    "TOP.ariane_testharness.i_sram.gen_cut[0].i_tc_sram_wrapper.i_tc_sram": {
+        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv",
+        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/common/local/util/tc_sram_wrapper.sv"
+    }
+}

--- a/source/vcd_parser.py
+++ b/source/vcd_parser.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-
+import re
 
 class VcdParser:
     # A class to parse VCD files and generate JSON about the design structure.
@@ -10,17 +10,115 @@ class VcdParser:
     def __init__(self):
         """Initializes an empty VcdParser instance."""
         self.design_info = {}
+        self.hierarchy = {}
 
     def parse_vcd(self, vcd_file_path, design_files_path):
         # Parses the VCD file and design files to generate a design hierarchy.
 
+        # generate hierarchy
+        with open(vcd_file_path, 'r') as vcd_file:
+          lines = vcd_file.readlines()
+
+        current_path = []
+        skip_level = 0
+        
+        for line in lines:
+          line = line.strip()
+
+          scope_module_match = re.match(r"\$scope module (\S+) \$end", line)
+          
+          scope_struct_match = re.match(r"\$scope struct (\S+) \$end", line)
+          scope_interface_match = re.match(r"\$scope interface (\S+) \$end", line)
+          scope_union_match = re.match(r"\$scope union (\S+) \$end", line)
+
+          if scope_module_match:
+              if skip_level == 0:
+                  module_name = scope_module_match.group(1)
+                  current_path.append(module_name)
+
+                  current_module = self.hierarchy
+                  for path_part in current_path:
+                      current_module = current_module.setdefault(path_part, {})
+
+          elif scope_struct_match or scope_interface_match or scope_union_match:
+              skip_level += 1
+
+          elif line == "$upscope $end":
+              if skip_level > 0:
+                  skip_level -= 1
+              elif current_path:
+                  current_path.pop()
+
+        # parse all modules and entities
+        module_declarations = {}
+        entity_to_class = {}
+        entity_to_path = {}
+        
+        module_declaration_pattern = r'module\s+(\w+)(?:\s+import\s+[\w\.\*\:]*;)?\s*(?:#\([\s\S]*?\))?\s*\('
+        module_entity_pattern = r'(\w+)\s+#\([\s\S]*?\)\s+(\w+)\s+\('
+        
+        for root, _, files in os.walk(design_files_path):
+          for file in files:
+              if file.endswith('.v') or file.endswith('.sv'):
+                  filepath = os.path.join(root, file)
+                  with open(filepath, 'r') as f:
+                      content = f.read()
+                      
+                      modules = re.findall(module_declaration_pattern, content)
+                      
+                      for module in modules:
+                          module_declarations[module] = filepath
+                      
+                      entities = re.findall(module_entity_pattern, content)
+                      
+                      for module_class, module_entity in entities:
+                          entity_to_path[module_entity] = filepath
+                          entity_to_class[module_entity] = module_class
+            
+        def process_node(node, current_path = ""):
+            for key, value in node.items():
+                full_path = f"{current_path}.{key}" if current_path else key
+                
+                self.design_info[full_path] = {
+                    "declaration_path": None,
+                    "initialization_path": None
+                }
+                
+                if isinstance(value, dict):
+                    process_node(value, full_path)
+                    
+        process_node(self.hierarchy)
+        
+        for path, _ in self.design_info.items():
+          module_name = path.split('.')[-1]
+                  
+          if(module_declarations.get(module_name) is not None):
+              self.design_info[path]['declaration_path'] = module_declarations.get(module_name)
+              continue
+          
+          if(entity_to_path.get(module_name) is not None):
+              self.design_info[path]['initialization_path'] = entity_to_path.get(module_name)
+              module_class = entity_to_class.get(module_name)
+              if(module_class is not None and module_declarations.get(module_class) is not None):
+                  self.design_info[path]['declaration_path'] = module_declarations.get(module_class)
+              continue
+        
+        
+        self.design_info = {
+          path: data for path, data in self.design_info.items()
+          if data['declaration_path'] is not None or data['initialization_path'] is not None
+        }
+        
         return self.design_info
 
     def export_json(self, output_path):
+        with open(output_path, 'w') as outfile:
+          json.dump(self.design_info, outfile, indent=4)
         # Util. Exports the parsed design info as a JSON file.
         pass
-
 
 if __name__ == "__main__":
     # Example usage
     parser = VcdParser()
+    parser.parse_vcd('/Users/sanzhar/vcd_parcer/cva6/cva6.vcd', '/Users/sanzhar/vcd_parcer/cva6/design')
+    parser.export_json('result.json')


### PR DESCRIPTION
Implemented vcd_parser function.

Work flow of function:
1. Takes vcd file and generates hierarchy in following form:
```
module: {
    submodule#1: {...},
    submodule#2: {...},
}
```
2. Parse all module declarations and entity initializations in design path. It is stored in following form:
```
module_declarations: {
    module_name: 'file/location/where/module/is/declared',
    ...
}

entity_to_path: {
    entity_name: 'file/location/where/module/is/initialized',
    ...
}

entity_to_class: {
    entity_name: class_of_entity/parent_module_of_entity,
    ...
}
```
3. Iterate through hierarchy generated previously and create a new object with following structure, using `module_declarations`, `entity_to_path`, `entity_to_class` dictionaries: 

```
{
    "TOP.ariane_testharness": {
        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/tb/ariane_testharness.sv",
        "initialization_path": null
    },
    "TOP.ariane_testharness.i_ariane": {
        "declaration_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/src/ariane.sv",
        "initialization_path": "/Users/sanzhar/vcd_parcer/cva6/design/corev_apu/fpga/src/ariane_xilinx.sv"
    },
}
```

Further improvements:
- I have encountered bug while testing. When parsing class names in Verilog code, the regex incorrectly matches the shorter name `spill_register instead` of the intended `spill_register_flushable`. This occurs in the following context:

```
module spill_register #(
  parameter type T      = logic,
  parameter bit  Bypass = 1'b0     // make this spill register transparent
) (
  input  logic clk_i   ,
  input  logic rst_ni  ,
  input  logic valid_i ,
  output logic ready_o ,
  input  T     data_i  ,
  output logic valid_o ,
  input  logic ready_i ,
  output T     data_o
);

  spill_register_flushable #(
    .T(T),
    .Bypass(Bypass)
  ) spill_register_flushable_i (
    .clk_i,
    .rst_ni,
    .valid_i,
    .flush_i(1'b0),
    .ready_o,
    .data_i,
    .valid_o,
    .ready_i,
    .data_o
  );
```

- I need to investigate on repetitive entity names. In cva6, usually entities do not have the same name. Repetitive entity names are used only in if-else statements.
