### PR TITLE
Summary: Add VCD parser, documentation, and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Custom.
+/source/*.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/documentation/vcd_parser.md
+++ b/documentation/vcd_parser.md
@@ -1,0 +1,51 @@
+# VCD Parser Module
+
+## Overview
+The **VCD Parser** module is designed to parse VCD (Value Change Dump) files and generate a structured representation of the design hierarchy, module declarations, and entity initializations. The module outputs a JSON file containing detailed information about the design structure for further analysis or processing.
+
+## Features
+- Parses VCD files to generate a design hierarchy.
+- Extracts and organizes module declarations, entity initializations, and parent module relationships.
+- Outputs a JSON representation of the design with detailed paths for module declarations and initializations.
+
+## Installation
+
+## Usage
+To use the VCD Parser module, ensure you have the following dependencies installed:
+
+- Python 3.6+
+- Standard Python libraries (`json`, `os`, `re`)
+
+Here is an example of how to use the module in your Python script:
+
+```python
+from vcd_parser import VcdParser
+
+# Initialize the parser
+parser = VcdParser()
+
+# Parse the VCD file and extract design information
+parser.parse_vcd(
+    '/path/to/vcd/hello_world.cv32a60x.vcd',
+    '/path/to/design/files/cva6'
+)
+
+# Export the parsed data to a JSON file
+parser.export_json('result.json')
+```
+
+## Output Structure
+The JSON output contains hierarchical design information, including module declarations and initialization paths. Below is an example of the output structure:
+
+```json
+{
+    "TOP.ariane_testharness": {
+        "declaration_path": "/path/to/design/corev_apu/tb/ariane_testharness.sv",
+        "initialization_path": null
+    },
+    "TOP.ariane_testharness.i_ariane": {
+        "declaration_path": "/path/to/design/corev_apu/src/ariane.sv",
+        "initialization_path": "/path/to/design/corev_apu/fpga/src/ariane_xilinx.sv"
+    }
+}
+```

--- a/source/vcd_parser.py
+++ b/source/vcd_parser.py
@@ -1,26 +1,133 @@
 # Copyright (c) 2024 texer.ai. All rights reserved.
-
 import json
 import os
+import re
 
+# Regex match constant strings.
+REGEX_STRING_MATCH_MODULE = r"\$scope module (\S+) \$end"
+REGEX_STRING_MATCH_STRUCT= r"\$scope struct (\S+) \$end"
+REGEX_STRING_MATCH_INTERFACE = r"\$scope interface (\S+) \$end"
+REGEX_STRING_MATCH_UNION = r"\$scope union (\S+) \$end"
+REGEX_STRING_MATCH_VERILOG_MODULE_DECLARE = r'module\s+(\w+)(?:\s+import\s+[\w\.\*\:]*;)?\s*(?:#\([\s\S]*?\))?\s*\('
+REGEX_STRING_MATCH_VERILOG_ENTITY = r'(\w+)\s+#\([\s\S]*?\)\s+(\w+)\s+\('
+
+# VCD related constants.
+STRING_VCD_UNSCOPE = "$upscope $end"
+
+# JSON object names.
+JSON_OBJ_NAME_DECLARE_PATH = "declaration_path"
+JSON_OBJ_NAME_INIT_PATH = "initialization_path"
 
 class VcdParser:
     # A class to parse VCD files and generate JSON about the design structure.
-
     def __init__(self):
         """Initializes an empty VcdParser instance."""
         self.design_info = {}
+        self.hierarchy = {}
 
     def parse_vcd(self, vcd_file_path, design_files_path):
         # Parses the VCD file and design files to generate a design hierarchy.
 
+        # Generate hierarchy
+        with open(vcd_file_path, 'r') as vcd_file:
+            lines = vcd_file.readlines()
+
+        current_path = []
+        skip_level = 0
+
+        for line in lines:
+            line = line.strip()
+
+            scope_module_match = re.match(REGEX_STRING_MATCH_MODULE, line)
+            scope_struct_match = re.match(REGEX_STRING_MATCH_STRUCT, line)
+            scope_interface_match = re.match(REGEX_STRING_MATCH_INTERFACE, line)
+            scope_union_match = re.match(REGEX_STRING_MATCH_UNION, line)
+
+            if scope_module_match:
+                if skip_level == 0:
+                    module_name = scope_module_match.group(1)
+                    current_path.append(module_name)
+
+                    current_module = self.hierarchy
+                    for path_part in current_path:
+                        current_module = current_module.setdefault(path_part, {})
+
+            elif scope_struct_match or scope_interface_match or scope_union_match:
+                skip_level += 1
+
+            elif line == STRING_VCD_UNSCOPE:
+                if skip_level > 0:
+                    skip_level -= 1
+                elif current_path:
+                    current_path.pop()
+
+        # parse all modules and entities
+        module_declarations = {}
+        entity_to_class = {}
+        entity_to_path = {}
+
+
+        for root, _, files in os.walk(design_files_path):
+            for file in files:
+                if file.endswith('.v') or file.endswith('.sv'):
+                    filepath = os.path.join(root, file)
+                    with open(filepath, 'r') as f:
+                        content = f.read()
+
+                        modules = re.findall(REGEX_STRING_MATCH_VERILOG_MODULE_DECLARE, content)
+
+                        for module in modules:
+                            module_declarations[module] = filepath
+
+                        entities = re.findall(REGEX_STRING_MATCH_VERILOG_ENTITY, content)
+
+                        for module_class, module_entity in entities:
+                            entity_to_path[module_entity] = filepath
+                            entity_to_class[module_entity] = module_class
+
+        def process_node(node, current_path = ""):
+            for key, value in node.items():
+                full_path = f"{current_path}.{key}" if current_path else key
+
+                self.design_info[full_path] = {
+                    JSON_OBJ_NAME_DECLARE_PATH: None,
+                    JSON_OBJ_NAME_INIT_PATH: None
+                }
+
+                if isinstance(value, dict):
+                    process_node(value, full_path)
+
+        process_node(self.hierarchy)
+
+        for path, _ in self.design_info.items():
+            module_name = path.split('.')[-1]
+
+            if(module_declarations.get(module_name) is not None):
+                self.design_info[path][JSON_OBJ_NAME_DECLARE_PATH] = module_declarations.get(module_name)
+                continue
+
+            if(entity_to_path.get(module_name) is not None):
+                self.design_info[path][JSON_OBJ_NAME_INIT_PATH] = entity_to_path.get(module_name)
+                module_class = entity_to_class.get(module_name)
+                if(module_class is not None and module_declarations.get(module_class) is not None):
+                    self.design_info[path][JSON_OBJ_NAME_DECLARE_PATH] = module_declarations.get(module_class)
+                continue
+
+
+        self.design_info = {
+            path: data for path, data in self.design_info.items()
+            if data[JSON_OBJ_NAME_DECLARE_PATH] is not None or data[JSON_OBJ_NAME_INIT_PATH] is not None
+        }
+
         return self.design_info
 
     def export_json(self, output_path):
-        # Util. Exports the parsed design info as a JSON file.
-        pass
-
+        # Utility function. Exports the parsed design info as a JSON file.
+        with open(output_path, 'w') as outfile:
+            json.dump(self.design_info, outfile, indent=4)
 
 if __name__ == "__main__":
     # Example usage
     parser = VcdParser()
+    parser.parse_vcd('/home/kabylkas/ailof/test_files/vcds/hello_world.cv32a60x.vcd', '/home/kabylkas/cva6')
+    parser.export_json('result.json')


### PR DESCRIPTION
This commit implements a functional VCD parser capable of extracting design hierarchies, module declarations, and entity initializations in a structured JSON. It includes updates to the .gitignore file to exclude JSON source files and introduces detailed documentation explaining the parser's usage, workflow, and output structure.