### PR TITLE
feat: enabled signal flatting for labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 source/*.json
 designs/*
 backup/
+test.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Previously, `vcd_parser` was skipping signals that were declared under label modules in design. Now they are joined to the parent module that is closest to them. 