### PR TITLE
Make search case-insensitive

### DIFF
--- a/source/models/model.py
+++ b/source/models/model.py
@@ -34,7 +34,8 @@ class DesignExplorerModel:
     def filter(self, keyword):
         self.working_list = []
         self.working_list_ids = []
+        keyword_lower = keyword.lower()
         for id, item in self.design_module_list.items():
-            if keyword in item:
+            if keyword_lower in item.lower():
                 self.working_list_ids.append(id)
                 self.working_list.append(item)

--- a/source/models/signal_model.py
+++ b/source/models/signal_model.py
@@ -28,7 +28,8 @@ class SignalExplorerModel:
     def filter(self, keyword):
         self.working_list = []
         self.working_list_ids = []
+        keyword_lower = keyword.lower()
         for id, item in self.selected_signals.items():
-            if keyword in item:
+            if keyword_lower in item.lower():
                 self.working_list_ids.append(id)
                 self.working_list.append(item)

--- a/source/views/signal_view.py
+++ b/source/views/signal_view.py
@@ -51,5 +51,5 @@ class SignalExplorerTerminalView:
 
     def print_message(self):
         print("Now, select the signals you would like to fuzz.\n")
-        print("Press Enter to proceed.")
+        print("Press any key to proceed.")
         print("")

--- a/source/views/terminal_view.py
+++ b/source/views/terminal_view.py
@@ -59,5 +59,5 @@ class DesignExplorerTerminalView:
         print("Ailof: AI assisted Logic Fuzzer. Texer.ai Ltd. (c) 2024.\n")
         print("The design is successfully parsed.")
         print("Select the modules in your design you would like to fuzz.\n")
-        print("Press Enter to start.")
+        print("Press any key to start.")
         print("")


### PR DESCRIPTION
This PR addresses #90 and #91.

1. Now, the welcome message says "Press any key to start."
2. Search is case-insensitive in both design and signal explorers.